### PR TITLE
Mistyped hyerlink

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This is the main source code repository for Unix. It contains the source code fo
 
 - This bot is still in development; if any issue arises feel free to create an issue on Github.
 #### **Contributing**
-If you are interested in contributing, please check out the [guidelines] (https://github.com/n-Ultima/UnixBot/blob/main/.github/CONTRIBUTING.md)
+If you are interested in contributing, please check out the [guidelines](https://github.com/n-Ultima/UnixBot/blob/main/.github/CONTRIBUTING.md)
 
 
 


### PR DESCRIPTION
Mistyped Hyperlink


I mistyped the hyperlink so it wouldnt redirect.
Fixed in ths patch



## Checklist

[//]: # "Put an x in [ ] to check the checkbox, like [x]"

- [ ] I discussed this pull request with Ultima or another developer before opening.
- [x ] I read the [contributing guidelines](https://www.github.com/n-Ultima/UnixBot/blob/main/.github/CONTRIBUTING.md).
- [x ] The changes in this pull request are tested.
- [ x] The changes in this pull request build(dotnet build -c Release /warnaserror) with no errors.

